### PR TITLE
fix: Prevent dynamic property to avoid deprecation warning on PHP >= 8.5

### DIFF
--- a/lib/Horde/ManageSieve.php
+++ b/lib/Horde/ManageSieve.php
@@ -145,6 +145,11 @@ class ManageSieve
     protected $_maxReferralCount = 15;
 
     /**
+     * @var array|array[]|null
+     */
+    private $_capability;
+
+    /**
      * Constructor.
      *
      * If username and password are provided connects to the server and logs


### PR DESCRIPTION
The following deprecation warning is thrown when running the unit tests for the Nextcloud mail app:

```
PHP Deprecated:  Creation of dynamic property Horde\ManageSieve::$_capability is deprecated in /home/runner/actions-runner/_work/mail/mail/nextcloud/apps/mail/vendor/nextcloud/horde-managesieve/lib/Horde/ManageSieve.php on line 867
```

This PR fixes that by defining the `$_capability` property.

Relates to https://github.com/nextcloud/mail/issues/12384.