### PR TITLE
fix(ci): update CI to PHP 8.1–8.5, drop EOL versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,14 +11,14 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [7.4, 8.0, 8.1]
+        php: [8.1, 8.2, 8.3, 8.4, 8.5]
         stability: [prefer-stable]
 
     name: PHP ${{ matrix.php }} - ${{ matrix.stability }}
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -34,5 +34,5 @@ jobs:
         run: ./vendor/bin/phpunit --coverage-clover clover.xml
 
       - name: Check code coverage
-        if: ${{ matrix.php == '8.1' }}
-        uses: codecov/codecov-action@v2.1.0
+        if: ${{ matrix.php == '8.4' }}
+        uses: codecov/codecov-action@v5

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "bytestream/horde-exception": "^2",
         "bytestream/horde-socket-client": "^2",
         "bytestream/horde-util": "^2"


### PR DESCRIPTION
Drop PHP 7.4 (EOL Nov 2022) and 8.0 (EOL Nov 2023). Add 8.2, 8.3, 8.4, and 8.5. Update actions/checkout to v4 and codecov-action to v5.

Assisted-by: Claude:claude-sonnet-4-6



## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
