### PR TITLE
chore(renovate): add Renovate config with dependency dashboard approval

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,36 @@
+{
+	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
+	"extends": [
+		"config:recommended",
+		"helpers:pinGitHubActionDigests",
+		":dependencyDashboard",
+		":semanticCommits",
+		":gitSignOff"
+	],
+	"timezone": "Europe/Vienna",
+	"schedule": [
+		"before 5am on wednesday"
+	],
+	"labels": [
+		"dependencies"
+	],
+	"dependencyDashboardApproval": true,
+	"rangeStrategy": "bump",
+	"minimumReleaseAge": "7 days",
+	"rebaseWhen": "conflicted",
+	"enabledManagers": [
+		"composer",
+		"github-actions"
+	],
+	"ignoreDeps": [
+		"php"
+	],
+	"vulnerabilityAlerts": {
+		"enabled": true,
+		"semanticCommitType": "fix",
+		"schedule": "before 7am every weekday",
+		"dependencyDashboardApproval": false,
+		"commitMessageSuffix": ""
+	},
+	"osvVulnerabilityAlerts": true
+}


### PR DESCRIPTION
All updates require approval via the dependency dashboard before a PR is opened. Vulnerability alerts bypass approval and run daily. Covers composer and github-actions managers.

Assisted-by: Claude:claude-sonnet-4-6



## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
